### PR TITLE
FIXED: use Buffer.from(string) instead of deprecated Buffer(string)

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -145,7 +145,7 @@ const enum RETVAL {
     ERR_PERM = 5,
 }
 
-const bytesNOOP = new Buffer("NOOP\r\n");
+const bytesNOOP = Buffer.from("NOOP\r\n");
 
 export class FTP extends EventEmitter {
 


### PR DESCRIPTION
Node.js 10 emits a warning when `Buffer(string)` is called from code outside `node_modules`.

This is a **Stability 0** API which means:

> Stability: 0 - Deprecated. The feature may emit warnings. **Backward compatibility is not guaranteed**.

See: https://nodejs.org/api/buffer.html#buffer_new_buffer_string_encoding