### PR TITLE
Fix name leading space

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -45,7 +45,7 @@ export default class Parser extends WritableStream {
 
     public static parseListEntry(line: string) {
         // var ret, info, month, day, year, hour, mins;
-        let ret: IListUnix | IListMsDos | null;
+        let ret: IListUnix | IListMsDos | null;
         // tslint:disable-next-line:no-conditional-assignment
         if ((ret = regListUnix(line))) {
             let name;
@@ -153,7 +153,7 @@ export default class Parser extends WritableStream {
                 info.date = new Date(year + "-" + monthS + "-" + dayS + "T00:00");
             }
             return info;
-        // tslint:disable-next-line:no-conditional-assignment
+            // tslint:disable-next-line:no-conditional-assignment
         } else if ((ret = regListMsDos(line))) {
             const month = parseInt(ret.month, 10);
             const day = parseInt(ret.date, 10);
@@ -206,7 +206,7 @@ export default class Parser extends WritableStream {
             debug("[parser] write()");
         }
         this._buffer += chunk.toString("binary");
-        let m: RegExpExecArray | null;
+        let m: RegExpExecArray | null;
         if (debug) {
             debug("[parser] buffer: " + this._buffer);
         }
@@ -277,7 +277,7 @@ interface IListMsDos {
     name: string;
 }
 
-const REX_LISTUNIX = /^([\-ld])((?:[\-r][\-w][\-xstT]){3})(\+)?\s+(\d+)\s+(\S+)\s+(\S+)\s+(\d+)\s+(?:(?:(\w{3})\s+(\d{1,2})\s+(\d{1,2}):(\d{2}))|(?:(\w{3})\s+(\d{1,2})\s+(\d{4})))\s+(.+)$/;
+const REX_LISTUNIX = /^([\-ld])((?:[\-r][\-w][\-xstT]){3})(\+)?\s+(\d+)\s+(\S+)\s+(\S+)\s+(\d+)\s+(?:(?:(\w{3})\s+(\d{1,2})\s+(\d{1,2}):(\d{2}))|(?:(\w{3})\s+(\d{1,2})\s+(\d{4})))\s(.+)$/;
 function regListUnix(text: string): IListUnix | null {
     // "^(?<type>[\\-ld])(?<permission>([\\-r][\\-w][\\-xstT]){3})(?<acl>(\\+))?\\s+(?<inodes>\\d+)\\s+(?<owner>\\S+)\\s+(?<group>\\S+)\\s+(?<size>\\d+)\\s+(?<timestamp>((?<month1>\\w{3})\\s+(?<date1>\\d{1,2})\\s+(?<hour>\\d{1,2}):(?<minute>\\d{2}))|((?<month2>\\w{3})\\s+(?<date2>\\d{1,2})\\s+(?<year>\\d{4})))\\s+(?<name>.+)$"
     const temp = text.match(REX_LISTUNIX);
@@ -301,7 +301,7 @@ function regListUnix(text: string): IListUnix | null {
 }
 
 const REX_LISTMSDOS = /^(\d{2})(?:\-|\/)(\d{2})(?:\-|\/)(\d{2,4})\s+(\d{2}):(\d{2})\s{0,1}([AaMmPp]{1,2})\s+(?:(\d+)|(<DIR>))\s+(.+)$/;
-function regListMsDos(text: string): IListMsDos | null {
+function regListMsDos(text: string): IListMsDos | null {
     // "^(?<month>\\d{2})(?:\\-|\\/)(?<date>\\d{2})(?:\\-|\\/)(?<year>\\d{2,4})\\s+(?<hour>\\d{2}):(?<minute>\\d{2})\\s{0,1}(?<ampm>[AaMmPp]{1,2})\\s+(?:(?<size>\\d+)|(?<isdir>\\<DIR\\>))\\s+(?<name>.+)$"
     const temp = text.match(REX_LISTMSDOS);
     return temp === null ? null : {

--- a/test/test-parser.js
+++ b/test/test-parser.js
@@ -1,14 +1,15 @@
 var Parser = require('../dist/parser').default,
-    parseListEntry = Parser.parseListEntry;
+  parseListEntry = Parser.parseListEntry;
 
 var path = require('path'),
-    assert = require('assert'),
-    inspect = require('util').inspect;
+  assert = require('assert'),
+  inspect = require('util').inspect;
 
 var group = path.basename(__filename, '.js') + '/';
 
 [
-  { source: 'drwxr-xr-x  10 root   root    4096 Dec 21  2012 usr',
+  {
+    source: 'drwxr-xr-x  10 root   root    4096 Dec 21  2012 usr',
     expected: {
       type: 'd',
       name: 'usr',
@@ -23,7 +24,8 @@ var group = path.basename(__filename, '.js') + '/';
     },
     what: 'Normal directory'
   },
-  { source: 'drwxrwxrwx   1 owner   group          0 Aug 31 2012 e-books',
+  {
+    source: 'drwxrwxrwx   1 owner   group          0 Aug 31 2012 e-books',
     expected: {
       type: 'd',
       name: 'e-books',
@@ -38,7 +40,8 @@ var group = path.basename(__filename, '.js') + '/';
     },
     what: 'Normal directory #2'
   },
-  { source: '-rw-rw-rw-   1 owner   group    7045120 Sep 02  2012 music.mp3',
+  {
+    source: '-rw-rw-rw-   1 owner   group    7045120 Sep 02  2012 music.mp3',
     expected: {
       type: '-',
       name: 'music.mp3',
@@ -53,7 +56,24 @@ var group = path.basename(__filename, '.js') + '/';
     },
     what: 'Normal file'
   },
-  { source: '-rw-rw-rw-+   1 owner   group    7045120 Sep 02  2012 music.mp3',
+  {
+    source: '-rw-rw-rw-   1 owner   group    7045120 Sep 02  2012  music.mp3',
+    expected: {
+      type: '-',
+      name: ' music.mp3',
+      target: undefined,
+      sticky: false,
+      rights: { user: 'rw', group: 'rw', other: 'rw' },
+      acl: false,
+      owner: 'owner',
+      group: 'group',
+      size: 7045120,
+      date: new Date('2012-09-02T00:00')
+    },
+    what: 'File starting with a space character'
+  },
+  {
+    source: '-rw-rw-rw-+   1 owner   group    7045120 Sep 02  2012 music.mp3',
     expected: {
       type: '-',
       name: 'music.mp3',
@@ -68,7 +88,8 @@ var group = path.basename(__filename, '.js') + '/';
     },
     what: 'File with ACL set'
   },
-  { source: 'drwxrwxrwt   7 root   root    4096 May 19 2012 tmp',
+  {
+    source: 'drwxrwxrwt   7 root   root    4096 May 19 2012 tmp',
     expected: {
       type: 'd',
       name: 'tmp',
@@ -83,7 +104,8 @@ var group = path.basename(__filename, '.js') + '/';
     },
     what: 'Directory with sticky bit and executable for others'
   },
-  { source: 'drwxrwx--t   7 root   root    4096 May 19 2012 tmp',
+  {
+    source: 'drwxrwx--t   7 root   root    4096 May 19 2012 tmp',
     expected: {
       type: 'd',
       name: 'tmp',
@@ -98,7 +120,8 @@ var group = path.basename(__filename, '.js') + '/';
     },
     what: 'Directory with sticky bit and executable for others #2'
   },
-  { source: 'drwxrwxrwT   7 root   root    4096 May 19 2012 tmp',
+  {
+    source: 'drwxrwxrwT   7 root   root    4096 May 19 2012 tmp',
     expected: {
       type: 'd',
       name: 'tmp',
@@ -113,7 +136,8 @@ var group = path.basename(__filename, '.js') + '/';
     },
     what: 'Directory with sticky bit and not executable for others'
   },
-  { source: 'drwxrwx--T   7 root   root    4096 May 19 2012 tmp',
+  {
+    source: 'drwxrwx--T   7 root   root    4096 May 19 2012 tmp',
     expected: {
       type: 'd',
       name: 'tmp',
@@ -128,14 +152,15 @@ var group = path.basename(__filename, '.js') + '/';
     },
     what: 'Directory with sticky bit and not executable for others #2'
   },
-  { source: 'total 871',
+  {
+    source: 'total 871',
     expected: null,
     what: 'Ignored line'
   },
-].forEach(function(v) {
+].forEach(function (v) {
   var result = parseListEntry(v.source),
-      msg = '[' + group + v.what + ']: parsed output mismatch.\n'
-            + 'Saw: ' + inspect(result) + '\n'
-            + 'Expected: ' + inspect(v.expected);
+    msg = '[' + group + v.what + ']: parsed output mismatch.\n'
+      + 'Saw: ' + inspect(result) + '\n'
+      + 'Expected: ' + inspect(v.expected);
   assert.deepEqual(result, v.expected, msg);
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,8 @@
 require('fs').readdirSync(__dirname).forEach(function(f) {
   if (f.substr(0, 5) === 'test-') {
+    console.log('running test', f);
     require('./' + f);
     console.log("%s done", f);
   }
 });
+


### PR DESCRIPTION
- fixes the list command eating leading spaces
- added a test for that

Having a filename like `   foo.mp3` would return a filename `foo.mp3`.

Note that tests won't run, running `npm test` returns the following error:
> Error: Cannot find module '..'

So I could not make sure the test was running.