### PR TITLE
update connection.ts import of EventEmitter

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,4 +1,4 @@
-import EventEmitter from "events";
+import { EventEmitter } from "events";
 import * as net from "net";
 import { StringDecoder } from "string_decoder";
 import * as tls from "tls";


### PR DESCRIPTION
Fixes 
node_modules/ftp-ts/esm/connection.d.ts:114:34 - error TS2507: Type 'typeof EventEmitter' is not a constructor function type.
on typescript 3.9.6